### PR TITLE
Add Dinosaur theme

### DIFF
--- a/css/dinosaur.css
+++ b/css/dinosaur.css
@@ -1,0 +1,196 @@
+/* ===== Dinosaur Theme ===== */
+
+/* Prehistoric background */
+[data-dino="true"] #game-screen {
+    background: linear-gradient(180deg, #1a0a2e 0%, #0d2818 40%, #1a3a1a 100%);
+}
+
+/* Dino key character */
+.effect-dino-key {
+    position: absolute;
+    font-size: 120px;
+    font-weight: 900;
+    pointer-events: none;
+    animation: dinoKeyPop 1.2s ease-out forwards;
+    z-index: 10;
+}
+
+@keyframes dinoKeyPop {
+    0% { transform: scale(0) rotate(-10deg); opacity: 1; }
+    15% { transform: scale(1.4) rotate(5deg); opacity: 1; }
+    30% { transform: scale(1) rotate(-2deg); opacity: 1; }
+    100% { transform: scale(1.5) rotate(0deg); opacity: 0; }
+}
+
+/* Dino stomp — screen shake handled in JS, this is the footprint */
+.effect-footprint {
+    position: absolute;
+    font-size: 80px;
+    pointer-events: none;
+    animation: footprintStamp 1.5s ease-out forwards;
+    filter: drop-shadow(0 0 10px rgba(139, 90, 43, 0.6));
+}
+
+@keyframes footprintStamp {
+    0% { transform: scale(2) rotate(var(--foot-angle, -15deg)); opacity: 0; }
+    15% { transform: scale(1) rotate(var(--foot-angle, -15deg)); opacity: 1; }
+    70% { transform: scale(1) rotate(var(--foot-angle, -15deg)); opacity: 0.6; }
+    100% { transform: scale(1) rotate(var(--foot-angle, -15deg)); opacity: 0; }
+}
+
+/* Volcano eruption */
+.effect-lava-particle {
+    position: absolute;
+    border-radius: 50%;
+    pointer-events: none;
+    animation: lavaErupt var(--duration, 1.5s) ease-out forwards;
+}
+
+@keyframes lavaErupt {
+    0% { transform: translate(0, 0) scale(1); opacity: 1; }
+    60% { opacity: 0.8; }
+    100% { transform: translate(var(--tx, 0), var(--ty, -300px)) scale(0.2); opacity: 0; }
+}
+
+/* Volcano base */
+.effect-volcano {
+    position: absolute;
+    pointer-events: none;
+    font-size: 100px;
+    animation: volcanoAppear 2s ease-out forwards;
+}
+
+@keyframes volcanoAppear {
+    0% { transform: scale(0.5); opacity: 0; }
+    20% { transform: scale(1.1); opacity: 1; }
+    80% { transform: scale(1); opacity: 0.8; }
+    100% { transform: scale(1); opacity: 0; }
+}
+
+/* Dino charge across screen */
+.effect-dino-charge {
+    position: absolute;
+    pointer-events: none;
+    font-size: 80px;
+    animation: dinoCharge var(--duration, 1.5s) linear forwards;
+}
+
+@keyframes dinoCharge {
+    0% { transform: translateX(var(--start-x, -100px)) scaleX(var(--dir, 1)); }
+    100% { transform: translateX(var(--end-x, 100vw)) scaleX(var(--dir, 1)); }
+}
+
+/* Egg crack */
+.effect-dino-egg {
+    position: absolute;
+    pointer-events: none;
+    font-size: 60px;
+    animation: eggCrack 2s ease-out forwards;
+}
+
+@keyframes eggCrack {
+    0% { transform: scale(0) rotate(0deg); opacity: 1; }
+    20% { transform: scale(1.2) rotate(10deg); opacity: 1; }
+    40% { transform: scale(1) rotate(-5deg); opacity: 1; }
+    60% { transform: scale(1.1) rotate(3deg); opacity: 1; }
+    70% { font-size: 60px; opacity: 1; }
+    80% { font-size: 70px; opacity: 1; }
+    100% { transform: scale(1.3) rotate(0deg); opacity: 0; }
+}
+
+/* Meteor */
+.effect-meteor {
+    position: absolute;
+    pointer-events: none;
+    font-size: 50px;
+    animation: meteorFall var(--duration, 1s) linear forwards;
+    filter: drop-shadow(0 0 15px #ff6600);
+}
+
+@keyframes meteorFall {
+    0% { transform: translate(var(--start-tx, 200px), var(--start-ty, -200px)) rotate(0deg); opacity: 1; }
+    90% { opacity: 1; }
+    100% { transform: translate(0, 0) rotate(360deg); opacity: 0; }
+}
+
+/* Fossil bones scatter */
+.effect-fossil {
+    position: absolute;
+    pointer-events: none;
+    font-size: 40px;
+    animation: fossilScatter var(--duration, 1.2s) ease-out forwards;
+}
+
+@keyframes fossilScatter {
+    0% { transform: translate(0, 0) rotate(0deg) scale(0.5); opacity: 1; }
+    100% { transform: translate(var(--tx, 100px), var(--ty, -100px)) rotate(var(--rot, 360deg)) scale(1); opacity: 0; }
+}
+
+/* Jungle leaf rain */
+.effect-leaf {
+    position: absolute;
+    pointer-events: none;
+    font-size: 40px;
+    animation: leafFall var(--duration, 3s) ease-in forwards;
+}
+
+@keyframes leafFall {
+    0% { transform: translateY(0) rotate(0deg) translateX(0); opacity: 1; }
+    50% { transform: translateY(50vh) rotate(180deg) translateX(var(--sway, 50px)); opacity: 0.8; }
+    100% { transform: translateY(100vh) rotate(360deg) translateX(0); opacity: 0; }
+}
+
+/* Dino footprint trail (mouse move) */
+.effect-paw-trail {
+    position: absolute;
+    pointer-events: none;
+    font-size: 20px;
+    animation: pawFade 1.2s ease-out forwards;
+    opacity: 0.6;
+}
+
+@keyframes pawFade {
+    0% { transform: scale(1) rotate(var(--paw-angle, 0deg)); opacity: 0.6; }
+    100% { transform: scale(0.5) rotate(var(--paw-angle, 0deg)); opacity: 0; }
+}
+
+/* Screen shake for stomp */
+@keyframes screenShake {
+    0%, 100% { transform: translate(0, 0); }
+    10% { transform: translate(-8px, 5px); }
+    20% { transform: translate(8px, -5px); }
+    30% { transform: translate(-5px, 8px); }
+    40% { transform: translate(5px, -3px); }
+    50% { transform: translate(-3px, 5px); }
+    60% { transform: translate(3px, -2px); }
+    70% { transform: translate(-2px, 3px); }
+    80% { transform: translate(2px, -1px); }
+    90% { transform: translate(-1px, 1px); }
+}
+
+.dino-shake {
+    animation: screenShake 0.5s ease-out;
+}
+
+/* Ambient pterodactyl */
+.effect-pterodactyl {
+    position: absolute;
+    pointer-events: none;
+    font-size: 50px;
+    animation: pterodactylFly var(--duration, 3s) ease-in-out forwards;
+}
+
+@keyframes pterodactylFly {
+    0% { transform: translate(var(--start-tx, -100px), 0) scaleX(var(--dir, 1)); opacity: 0; }
+    10% { opacity: 1; }
+    90% { opacity: 1; }
+    100% { transform: translate(var(--end-tx, 100vw), var(--drift, -50px)) scaleX(var(--dir, 1)); opacity: 0; }
+}
+
+/* Jungle background elements */
+.jungle-bg-element {
+    position: absolute;
+    pointer-events: none;
+    opacity: 0.15;
+    font-size: 60px;
+}

--- a/css/home.css
+++ b/css/home.css
@@ -184,3 +184,19 @@
 [data-starwars="true"] .home-subtitle::after {
     content: ' ⚔️ May the Force be with you!';
 }
+
+/* ===== Dinosaur Home Theme Override ===== */
+[data-dino="true"] .home-title {
+    background: linear-gradient(135deg, #4caf50, #ff9800, #8bc34a);
+    -webkit-background-clip: text;
+    background-clip: text;
+}
+
+[data-dino="true"] .start-button {
+    background: linear-gradient(135deg, #2e7d32, #689f38);
+    box-shadow: 0 4px 20px rgba(46, 125, 50, 0.4);
+}
+
+[data-dino="true"] .home-subtitle::after {
+    content: ' 🦕 Roar into adventure!';
+}

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="css/home.css">
     <link rel="stylesheet" href="css/game.css">
     <link rel="stylesheet" href="css/starwars.css">
+    <link rel="stylesheet" href="css/dinosaur.css">
 </head>
 <body>
     <!-- Home Screen -->
@@ -65,6 +66,16 @@
                         <span class="toggle-slider"></span>
                     </label>
                 </div>
+                <div class="setting-row">
+                    <label class="setting-label" for="dino-toggle">
+                        <span class="setting-icon">🦕</span>
+                        <span>Dinosaur Theme</span>
+                    </label>
+                    <label class="toggle-switch">
+                        <input type="checkbox" id="dino-toggle">
+                        <span class="toggle-slider"></span>
+                    </label>
+                </div>
             </div>
 
             <button id="start-btn" class="start-button">
@@ -83,6 +94,7 @@
     <script src="js/utils.js"></script>
     <script src="js/effects.js"></script>
     <script src="js/starwars.js"></script>
+    <script src="js/dinosaur.js"></script>
     <script src="js/game.js"></script>
     <script src="js/home.js"></script>
     <script src="js/app.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -15,7 +15,7 @@ const App = {
     startGame() {
         this.homeScreen.classList.remove('active');
         this.gameScreen.classList.add('active');
-        Game.start(Home.isStarWarsEnabled());
+        Game.start(Home.isStarWarsEnabled(), Home.isDinoEnabled());
     },
 
     showHome() {

--- a/js/dinosaur.js
+++ b/js/dinosaur.js
@@ -1,0 +1,315 @@
+/* ===== Dinosaur Theme Effects ===== */
+
+const DinosaurEffects = {
+    layer: null,
+    jungleCreated: false,
+
+    init(layer) {
+        this.layer = layer;
+    },
+
+    dinoColors: ['#4caf50', '#8bc34a', '#ff9800', '#795548', '#ff5722', '#cddc39', '#2e7d32'],
+
+    dinos: ['🦕', '🦖', '🐊'],
+    babies: ['🐣', '🐥', '🦎', '🐢'],
+    foliage: ['🌿', '🍃', '🌴', '🍀', '☘️', '🌱', '🪴'],
+    fossils: ['🦴', '💀', '🦷'],
+
+    keyEffects: [
+        'dinoStomp', 'volcanoEruption', 'dinoCharge',
+        'eggHatch', 'fossilDig', 'jungleLeafRain', 'pterodactylFlyby'
+    ],
+
+    clickEffects: [
+        'meteorStrike', 'fossilDig', 'dinoStomp', 'volcanoEruption'
+    ],
+
+    moveEffects: ['footprintTrail'],
+
+    onKey(e) {
+        // Spacebar Easter egg: display "LEO"
+        if (e.key === ' ') {
+            this.spacebarLEO();
+            return;
+        }
+
+        const char = Utils.keyToDisplay(e);
+        const pos = Utils.randomPosition();
+
+        // Always show the dino-styled character
+        this.dinoLetter(char, pos);
+
+        // R key Easter egg: always show the robot emoji
+        if (e.key === 'r' || e.key === 'R') {
+            this.robotEmoji(pos);
+        }
+
+        // Plus a random dino effect
+        const effect = Utils.pick(this.keyEffects);
+        this[effect](char, pos);
+    },
+
+    onClick(x, y) {
+        const effect = Utils.pick(this.clickEffects);
+        this[effect]('', { x, y });
+    },
+
+    onMove(x, y) {
+        this.footprintTrail(x, y);
+    },
+
+    createJungle() {
+        if (this.jungleCreated) return;
+        this.jungleCreated = true;
+
+        const plants = ['🌿', '🌴', '🪴', '🌱', '🍃'];
+        for (let i = 0; i < 20; i++) {
+            const el = document.createElement('div');
+            el.className = 'jungle-bg-element';
+            el.textContent = Utils.pick(plants);
+            el.style.left = Utils.randomFloat(0, 100) + '%';
+            el.style.top = Utils.randomFloat(60, 95) + '%';
+            el.style.fontSize = Utils.randomInt(40, 100) + 'px';
+            el.style.opacity = Utils.randomFloat(0.08, 0.2);
+            this.layer.appendChild(el);
+        }
+    },
+
+    removeJungle() {
+        if (!this.jungleCreated) return;
+        this.jungleCreated = false;
+        this.layer.querySelectorAll('.jungle-bg-element').forEach(el => el.remove());
+    },
+
+    // ===== Individual Effects =====
+
+    dinoLetter(char, pos) {
+        const color = Utils.pick(this.dinoColors);
+        const el = Utils.createEffect('effect-dino-key', {
+            left: pos.x + 'px',
+            top: pos.y + 'px',
+            color: color,
+            textShadow: `0 0 15px ${color}, 0 0 30px ${color}`,
+            transform: 'translate(-50%, -50%)',
+        }, this.layer, 1200);
+        el.textContent = char;
+    },
+
+    dinoStomp(char, pos) {
+        // Screen shake
+        const gameScreen = document.getElementById('game-screen');
+        gameScreen.classList.remove('dino-shake');
+        void gameScreen.offsetWidth; // force reflow
+        gameScreen.classList.add('dino-shake');
+        setTimeout(() => gameScreen.classList.remove('dino-shake'), 500);
+
+        // Footprint
+        const angle = Utils.randomInt(-30, 30);
+        const el = Utils.createEffect('effect-footprint', {
+            left: pos.x + 'px',
+            top: pos.y + 'px',
+            transform: 'translate(-50%, -50%)',
+            '--foot-angle': angle + 'deg',
+        }, this.layer, 1500);
+        el.textContent = '🐾';
+    },
+
+    volcanoEruption(char, pos) {
+        // Volcano emoji
+        const el = Utils.createEffect('effect-volcano', {
+            left: pos.x + 'px',
+            top: pos.y + 'px',
+            transform: 'translate(-50%, -50%)',
+        }, this.layer, 2000);
+        el.textContent = '🌋';
+
+        // Lava particles
+        const lavaColors = ['#ff4500', '#ff6600', '#ff8c00', '#ffd700', '#ff0000', '#cc3300'];
+        for (let i = 0; i < 25; i++) {
+            const angle = Utils.randomFloat(-Math.PI * 0.8, -Math.PI * 0.2);
+            const distance = Utils.randomInt(100, 300);
+            const tx = Math.cos(angle) * distance;
+            const ty = Math.sin(angle) * distance;
+            const size = Utils.randomInt(6, 16);
+            const color = Utils.pick(lavaColors);
+            const duration = Utils.randomFloat(0.8, 1.8);
+
+            Utils.createEffect('effect-lava-particle', {
+                left: pos.x + 'px',
+                top: (pos.y - 30) + 'px',
+                width: size + 'px',
+                height: size + 'px',
+                background: `radial-gradient(circle, ${color}, #8b0000)`,
+                '--tx': tx + 'px',
+                '--ty': ty + 'px',
+                '--duration': duration + 's',
+                animationDelay: Utils.randomFloat(0, 0.3) + 's',
+            }, this.layer, duration * 1000 + 300);
+        }
+    },
+
+    dinoCharge(char, pos) {
+        const dino = Utils.pick(this.dinos);
+        const y = Utils.randomInt(100, window.innerHeight - 100);
+        const goingRight = Math.random() > 0.5;
+        const duration = Utils.randomFloat(1.2, 2.5);
+
+        const el = Utils.createEffect('effect-dino-charge', {
+            left: goingRight ? '-120px' : (window.innerWidth + 120) + 'px',
+            top: y + 'px',
+            '--start-x': '0px',
+            '--end-x': goingRight ? (window.innerWidth + 240) + 'px' : -(window.innerWidth + 240) + 'px',
+            '--dir': goingRight ? '1' : '-1',
+            '--duration': duration + 's',
+        }, this.layer, duration * 1000);
+        el.textContent = dino;
+    },
+
+    eggHatch(char, pos) {
+        for (let i = 0; i < 3; i++) {
+            const offsetX = Utils.randomInt(-80, 80);
+            const offsetY = Utils.randomInt(-40, 40);
+
+            const egg = Utils.createEffect('effect-dino-egg', {
+                left: (pos.x + offsetX) + 'px',
+                top: (pos.y + offsetY) + 'px',
+                transform: 'translate(-50%, -50%)',
+            }, this.layer, 2000);
+            egg.textContent = '🥚';
+
+            // Baby dino appears after egg animation
+            setTimeout(() => {
+                const baby = Utils.createEffect('effect-dino-egg', {
+                    left: (pos.x + offsetX) + 'px',
+                    top: (pos.y + offsetY) + 'px',
+                    transform: 'translate(-50%, -50%)',
+                }, this.layer, 1500);
+                baby.textContent = Utils.pick(this.babies);
+            }, 1200);
+        }
+    },
+
+    meteorStrike(char, pos) {
+        for (let i = 0; i < 5; i++) {
+            const startTx = Utils.randomInt(100, 400);
+            const startTy = Utils.randomInt(-400, -150);
+            const duration = Utils.randomFloat(0.5, 1.2);
+
+            const meteor = Utils.createEffect('effect-meteor', {
+                left: pos.x + 'px',
+                top: pos.y + 'px',
+                '--start-tx': startTx + 'px',
+                '--start-ty': startTy + 'px',
+                '--duration': duration + 's',
+                animationDelay: Utils.randomFloat(0, 0.3) + 's',
+            }, this.layer, duration * 1000 + 300);
+            meteor.textContent = '☄️';
+        }
+
+        // Impact flash
+        setTimeout(() => {
+            Utils.createEffect('effect-flash', {
+                background: 'rgba(255, 100, 0, 0.2)',
+            }, this.layer, 400);
+        }, 600);
+    },
+
+    fossilDig(char, pos) {
+        for (let i = 0; i < 8; i++) {
+            const angle = Utils.randomFloat(0, Math.PI * 2);
+            const distance = Utils.randomInt(60, 180);
+            const tx = Math.cos(angle) * distance;
+            const ty = Math.sin(angle) * distance;
+            const rotation = Utils.randomInt(0, 720);
+            const duration = Utils.randomFloat(0.8, 1.5);
+
+            const fossil = Utils.createEffect('effect-fossil', {
+                left: pos.x + 'px',
+                top: pos.y + 'px',
+                '--tx': tx + 'px',
+                '--ty': ty + 'px',
+                '--rot': rotation + 'deg',
+                '--duration': duration + 's',
+            }, this.layer, duration * 1000);
+            fossil.textContent = Utils.pick(this.fossils);
+        }
+    },
+
+    jungleLeafRain() {
+        for (let i = 0; i < 12; i++) {
+            const x = Utils.randomInt(0, window.innerWidth);
+            const leaf = Utils.pick(this.foliage);
+            const duration = Utils.randomFloat(2, 4);
+            const sway = Utils.randomInt(-80, 80);
+            const size = Utils.randomInt(30, 60);
+
+            const el = Utils.createEffect('effect-leaf', {
+                left: x + 'px',
+                top: '-80px',
+                fontSize: size + 'px',
+                '--duration': duration + 's',
+                '--sway': sway + 'px',
+                animationDelay: Utils.randomFloat(0, 0.5) + 's',
+            }, this.layer, duration * 1000 + 500);
+            el.textContent = leaf;
+        }
+    },
+
+    pterodactylFlyby() {
+        const y = Utils.randomInt(30, window.innerHeight * 0.4);
+        const goingRight = Math.random() > 0.5;
+        const duration = Utils.randomFloat(2, 4);
+        const drift = Utils.randomInt(-80, 80);
+
+        const el = Utils.createEffect('effect-pterodactyl', {
+            left: goingRight ? '-80px' : (window.innerWidth + 80) + 'px',
+            top: y + 'px',
+            '--start-tx': '0px',
+            '--end-tx': goingRight ? (window.innerWidth + 160) + 'px' : -(window.innerWidth + 160) + 'px',
+            '--dir': goingRight ? '1' : '-1',
+            '--drift': drift + 'px',
+            '--duration': duration + 's',
+        }, this.layer, duration * 1000);
+        el.textContent = '🦅';
+    },
+
+    footprintTrail(x, y) {
+        const angle = Utils.randomInt(-20, 20);
+        const el = Utils.createEffect('effect-paw-trail', {
+            left: x + 'px',
+            top: y + 'px',
+            transform: 'translate(-50%, -50%)',
+            '--paw-angle': angle + 'deg',
+        }, this.layer, 1200);
+        el.textContent = '🐾';
+    },
+
+    spacebarLEO() {
+        const letters = ['L', 'E', 'O'];
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+        const xPositions = [vw * 0.2, vw * 0.5, vw * 0.8];
+        const colors = ['#4caf50', '#ff9800', '#ff5722'];
+
+        letters.forEach((letter, i) => {
+            setTimeout(() => {
+                const el = Utils.createEffect('effect-leo-letter', {
+                    left: xPositions[i] + 'px',
+                    top: (vh / 2) + 'px',
+                    color: colors[i],
+                    textShadow: `0 0 20px ${colors[i]}, 0 0 40px ${colors[i]}`,
+                }, this.layer, 2500);
+                el.textContent = letter;
+            }, i * 200);
+        });
+    },
+
+    robotEmoji(pos) {
+        const el = Utils.createEffect('effect-robot', {
+            left: pos.x + 'px',
+            top: pos.y + 'px',
+            transform: 'translate(-50%, -50%)',
+        }, this.layer, 2000);
+        el.textContent = '🤖';
+    },
+};

--- a/js/game.js
+++ b/js/game.js
@@ -3,6 +3,7 @@
 const Game = {
     active: false,
     starWarsMode: false,
+    dinoMode: false,
     effectsLayer: null,
     canvas: null,
     ctx: null,
@@ -14,6 +15,7 @@ const Game = {
         this.ctx = this.canvas.getContext('2d');
         Effects.init(this.effectsLayer);
         StarWarsEffects.init(this.effectsLayer);
+        DinosaurEffects.init(this.effectsLayer);
         this._resizeCanvas();
         window.addEventListener('resize', () => this._resizeCanvas());
     },
@@ -23,14 +25,17 @@ const Game = {
         this.canvas.height = window.innerHeight;
     },
 
-    start(starWarsMode) {
+    start(starWarsMode, dinoMode) {
         this.active = true;
         this.starWarsMode = starWarsMode;
+        this.dinoMode = dinoMode;
         this._enterFullscreen();
         this._bindEvents();
 
         if (starWarsMode) {
             StarWarsEffects.createStarfield();
+        } else if (dinoMode) {
+            DinosaurEffects.createJungle();
         }
     },
 
@@ -42,12 +47,14 @@ const Game = {
 
         if (this.starWarsMode) {
             StarWarsEffects.removeStarfield();
+        } else if (this.dinoMode) {
+            DinosaurEffects.removeJungle();
         }
     },
 
     _cleanup() {
-        // Remove all effect elements except starfield (handled separately)
-        const effects = this.effectsLayer.querySelectorAll(':not(.starfield-star)');
+        // Remove all effect elements except persistent backgrounds (handled separately)
+        const effects = this.effectsLayer.querySelectorAll(':not(.starfield-star):not(.jungle-bg-element)');
         effects.forEach(el => el.remove());
         this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     },
@@ -80,7 +87,9 @@ const Game = {
     },
 
     _getEffectEngine() {
-        return this.starWarsMode ? StarWarsEffects : Effects;
+        if (this.starWarsMode) return StarWarsEffects;
+        if (this.dinoMode) return DinosaurEffects;
+        return Effects;
     },
 
     // ===== Event Handlers =====

--- a/js/home.js
+++ b/js/home.js
@@ -3,12 +3,14 @@
 const Home = {
     themeToggle: null,
     starwarsToggle: null,
+    dinoToggle: null,
     themeIcon: null,
     startBtn: null,
 
     init() {
         this.themeToggle = document.getElementById('theme-toggle');
         this.starwarsToggle = document.getElementById('starwars-toggle');
+        this.dinoToggle = document.getElementById('dino-toggle');
         this.themeIcon = document.getElementById('theme-icon');
         this.startBtn = document.getElementById('start-btn');
 
@@ -18,17 +20,27 @@ const Home = {
         // Bind events
         this.themeToggle.addEventListener('change', () => this._onThemeChange());
         this.starwarsToggle.addEventListener('change', () => this._onStarWarsChange());
+        this.dinoToggle.addEventListener('change', () => this._onDinoChange());
         this.startBtn.addEventListener('click', () => App.startGame());
     },
 
     _loadPreferences() {
         const darkMode = localStorage.getItem('keyboard-smash-dark') === 'true';
         const starWars = localStorage.getItem('keyboard-smash-starwars') === 'true';
+        const dino = localStorage.getItem('keyboard-smash-dino') === 'true';
 
         this.themeToggle.checked = darkMode;
-        this.starwarsToggle.checked = starWars;
+        // Only one game theme at a time; dino takes precedence if both saved
+        if (dino) {
+            this.dinoToggle.checked = true;
+            this.starwarsToggle.checked = false;
+        } else {
+            this.starwarsToggle.checked = starWars;
+            this.dinoToggle.checked = false;
+        }
         this._applyTheme(darkMode);
-        this._applyStarWars(starWars);
+        this._applyStarWars(this.starwarsToggle.checked);
+        this._applyDino(this.dinoToggle.checked);
     },
 
     _onThemeChange() {
@@ -39,8 +51,24 @@ const Home = {
 
     _onStarWarsChange() {
         const sw = this.starwarsToggle.checked;
+        if (sw) {
+            this.dinoToggle.checked = false;
+            this._applyDino(false);
+            localStorage.setItem('keyboard-smash-dino', false);
+        }
         this._applyStarWars(sw);
         localStorage.setItem('keyboard-smash-starwars', sw);
+    },
+
+    _onDinoChange() {
+        const dino = this.dinoToggle.checked;
+        if (dino) {
+            this.starwarsToggle.checked = false;
+            this._applyStarWars(false);
+            localStorage.setItem('keyboard-smash-starwars', false);
+        }
+        this._applyDino(dino);
+        localStorage.setItem('keyboard-smash-dino', dino);
     },
 
     _applyTheme(dark) {
@@ -52,7 +80,15 @@ const Home = {
         document.documentElement.setAttribute('data-starwars', enabled);
     },
 
+    _applyDino(enabled) {
+        document.documentElement.setAttribute('data-dino', enabled);
+    },
+
     isStarWarsEnabled() {
         return this.starwarsToggle.checked;
+    },
+
+    isDinoEnabled() {
+        return this.dinoToggle.checked;
     },
 };


### PR DESCRIPTION
## 🦕 Dinosaur Theme

Adds an optional Dinosaur theme as a new game mode alongside the existing Star Wars theme.

### Effects included:
- **Dino stomp** — Screen shake + footprint animation on keypress
- **Volcano eruption** — Lava particles burst upward
- **Dino charge** — T-Rex/dinos charge across the screen
- **Egg hatch** — Eggs appear and crack open to reveal baby dinos
- **Meteor shower** — Meteors streak across the screen on click
- **Fossil dig** — Bones scatter from click point
- **Jungle leaf rain** — Ferns and leaves rain down
- **Pterodactyl flyby** — Pterodactyls soar across the sky
- **Footprint trail** — Dino paw prints follow mouse movement
- **Prehistoric jungle background** — Ambient foliage

### Other changes:
- Themes are mutually exclusive (enabling Dino disables Star Wars and vice versa)
- Home screen styling updates when Dino theme is active
- Includes LEO spacebar and robot emoji Easter eggs
- New `dinosaur.js` and `dinosaur.css` following existing theme architecture

Closes #5