### PR TITLE
Add tablet/touch support with multi-touch

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -3,6 +3,7 @@
     background: var(--game-bg);
     cursor: crosshair;
     overflow: hidden;
+    touch-action: none;
 }
 
 #game-canvas {

--- a/js/game.js
+++ b/js/game.js
@@ -141,6 +141,34 @@ const Game = {
         if (this.active) e.preventDefault();
     },
 
+    _onTouchStart(e) {
+        if (!this.active) return;
+        e.preventDefault();
+        // Trigger a click effect for each finger
+        for (const touch of e.changedTouches) {
+            this._getEffectEngine().onClick(touch.clientX, touch.clientY);
+        }
+    },
+
+    _onTouchMove(e) {
+        if (!this.active) return;
+        e.preventDefault();
+
+        const now = Date.now();
+        if (now - this.moveThrottle < 33) return;
+        this.moveThrottle = now;
+
+        // Trail effect for each active finger
+        for (const touch of e.touches) {
+            this._getEffectEngine().onMove(touch.clientX, touch.clientY);
+        }
+    },
+
+    _onTouchEnd(e) {
+        if (!this.active) return;
+        e.preventDefault();
+    },
+
     // ===== Event Binding =====
 
     _boundHandlers: {},
@@ -152,6 +180,9 @@ const Game = {
             mousemove: (e) => this._onMouseMove(e),
             wheel: (e) => this._onWheel(e),
             contextmenu: (e) => this._onContextMenu(e),
+            touchstart: (e) => this._onTouchStart(e),
+            touchmove: (e) => this._onTouchMove(e),
+            touchend: (e) => this._onTouchEnd(e),
             fullscreenchange: () => this._handleFullscreenChange(),
         };
 


### PR DESCRIPTION
## 📱 Touch Support

Adds full touch event handling so the game works on tablets and phones.

### Changes:
- **`touchstart`** → triggers click effects at each touch point
- **`touchmove`** → triggers trail effects for each active finger (throttled to ~30fps)
- **`touchend`** → prevents default browser behavior
- **Multi-touch** — each finger spawns effects independently, so multiple toddler fingers = more fun
- **`touch-action: none`** CSS on game screen prevents browser scroll/zoom/back gestures

### Files changed:
- `js/game.js` — touch event handlers and binding
- `css/game.css` — `touch-action: none` on game screen

Closes #8